### PR TITLE
implemented 69

### DIFF
--- a/StudyBuddy/Models/UploadModel/DocumentsModel.swift
+++ b/StudyBuddy/Models/UploadModel/DocumentsModel.swift
@@ -4,48 +4,55 @@
 //
 //  Created by Krish Kapoor on 20/02/2025.
 //
-
 import Foundation
-
+enum DocumentType: String, Codable {
+    case file
+    case folder
+}
 /// Represents a document in the StudyBuddy app.
 /// Stores the document name, raw content, parsed content (if available), and creation date.
-struct Document: Identifiable {
+struct Document: Identifiable, Codable {
     let id: UUID  // Unique identifier for each document
     let fileName: String  // Name of the document file
     let content: String  // Raw content of the document
     let dateCreated: Date  // Timestamp when the document was created
     var parsedContent: String?  // Stores extracted text after parsing (optional)
     var fileData: Data? // Data of the Document for file storage needs
-
+    var fileURL: String? // URL to download from Cloud Storage (for files)
+    var type: DocumentType = .file // .file or .folder, default to file
+    var isFavorite: Bool = false // For the favorites feature
+    var firestoreDocumentId: String? // To store the Firestore document ID
     /// Initializes a new document with a given file name and content.
     /// - Parameters:
     ///   - fileName: Name of the document file.
     ///   - content: Raw text content of the document.
     ///   - parsedContent: Extracted text content after processing (default: nil).
     ///   - fileData: Data of the document (default: nil).
-    init(fileName: String, content: String, parsedContent: String? = nil, fileData: Data? = nil) {
+    init(fileName: String, content: String, parsedContent: String? = nil, fileData: Data? = nil, fileURL: String? = nil, type: DocumentType = .file, isFavorite: Bool = false) {
         self.id = UUID()  // Generate a unique ID
         self.fileName = fileName
         self.content = content
         self.dateCreated = Date()  // Set creation timestamp
         self.parsedContent = parsedContent
         self.fileData = fileData
+        self.fileURL = fileURL
+        self.type = type
+        self.isFavorite = isFavorite
+        self.firestoreDocumentId = nil // Initialize as nil
     }
-
     /// Updates the parsed content of the document after text extraction.
     /// - Parameter parsed: The extracted text from the document.
     mutating func updateParsedContent(_ parsed: String) {
         self.parsedContent = parsed
     }
 }
-
 // Example usage:
 /*
  // Creating a document instance
  var document = Document(fileName: "lecture.pdf", content: "raw content")
-
  // Parsing text from a PDF and updating parsed content
  extractTextFromPDF(pdfURL: url) { parsedText in
      document.updateParsedContent(parsedText)
  }
 */
+

--- a/StudyBuddy/Screens/FileViewer/FileViewer.swift
+++ b/StudyBuddy/Screens/FileViewer/FileViewer.swift
@@ -4,15 +4,14 @@
 //
 //  Created by alina on 2025/3/3.
 //
-
 import SwiftUI
+import QuickLook
 
 enum FileName: String, CaseIterable, Identifiable {
     case allFile = "All Files"
     case recent = "Recents"
     case favorites = "Favorites"
     case folders = "Folders"
-
     var id: String { self.rawValue }
 }
 
@@ -28,7 +27,6 @@ struct FileViewer: View {
                     .font(.title)
                     .bold()
                     .padding(.horizontal)
-
                 Picker("Select a tab", selection: $selection) {
                     ForEach(FileName.allCases) { file in
                         Text(file.rawValue).tag(file)
@@ -36,46 +34,158 @@ struct FileViewer: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
-
                 // Content based on selected tab
                 switch selection {
                 case .allFile:
-                    AllView(fileViewerViewModel: FileViewerViewModel())
+                    AllView(fileViewerViewModel: fileViewerViewModel)
                 case .recent:
                     Text("Recents View")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 case .favorites:
-                    Text("Favorites View")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    AllView(fileViewerViewModel: fileViewerViewModel, isFavoritesView: true) // Use AllView for Favorites
                 case .folders:
                     Text("Folders View")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .sheet(isPresented: $fileViewerViewModel.isPresentingFilePreview, onDismiss: {
+                fileViewerViewModel.selectedFileURL = nil
+                fileViewerViewModel.localFileURL = nil
+            }) {
+                if let url = fileViewerViewModel.localFileURL {
+                    QLPreviewView(url: url, isPresented: $fileViewerViewModel.isPresentingFilePreview)
+                } else if fileViewerViewModel.isLoading {
+                    ProgressView("Downloading File...")
+                } else if let error = fileViewerViewModel.errorMessage {
+                    Text("Error: \(error)")
                 }
             }
         }
     }
 }
 
+struct QLPreviewView: UIViewControllerRepresentable {
+    let url: URL
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let previewController = QLPreviewController()
+        previewController.dataSource = context.coordinator
+        let navigationController = UINavigationController(rootViewController: previewController)
+        let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: context.coordinator, action: #selector(context.coordinator.dismissPreview))
+        previewController.navigationItem.rightBarButtonItem = doneButton
+        return navigationController
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        // No need to update here for this simple case
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url, isPresented: $isPresented)
+    }
+
+    class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let previewItemURL: URL
+        @Binding var isPresented: Bool
+
+        init(url: URL, isPresented: Binding<Bool>) {
+            self.previewItemURL = url
+            _isPresented = isPresented
+            super.init()
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+            return 1
+        }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            return previewItemURL as NSURL as QLPreviewItem
+        }
+
+        @objc func dismissPreview() {
+            isPresented = false
+        }
+    }
+}
+
 struct AllView: View {
-    @ObservedObject var fileViewerViewModel = FileViewerViewModel()
+    @ObservedObject var fileViewerViewModel: FileViewerViewModel
+    let columns: [GridItem] = Array(repeating: .init(.flexible()), count: 3)
+    var isFavoritesView: Bool = false // New flag
 
     var body: some View {
         ScrollView {
-            HStack {
-                ForEach(fileViewerViewModel.fileLibrary, id: \.self) { document in
-                    VStack {
-                        Image(systemName: "doc")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 50, height: 50)
-                            .padding(4)
-                        Text(document)
-                            .scaledToFit()
+            if fileViewerViewModel.isLoading {
+                ProgressView("Fetching Documents...")
+            } else if let errorMessage = fileViewerViewModel.errorMessage {
+                Text("Error: \(errorMessage)")
+            } else {
+                let displayedDocuments = isFavoritesView ? fileViewerViewModel.favoriteDocuments : fileViewerViewModel.documents
+
+                if displayedDocuments.isEmpty {
+                    Text("No documents found.")
+                } else {
+                    LazyVGrid(columns: columns, spacing: 16) {
+                        ForEach(displayedDocuments) { document in
+                            DocumentItemView(document: document, viewModel: fileViewerViewModel)
+                        }
                     }
-                    .padding(.horizontal)
+                    .padding()
                 }
             }
         }
+    }
+}
+
+struct DocumentItemView: View {
+    let document: Document
+    @ObservedObject var viewModel: FileViewerViewModel
+    @State private var isShowingFavoriteAlert = false
+    @State private var favoriteAlertMessage = ""
+    var body: some View {
+        VStack {
+            if document.type == .folder {
+                Image(systemName: "folder.fill") // Folder icon
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 60, height: 60)
+                    .foregroundColor(.blue) // Customize folder color
+                    .padding(4)
+            } else {
+                Image(systemName: "doc.fill") // Default document icon
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 60, height: 60)
+                    .foregroundColor(.gray)
+                    .padding(4)
+            }
+            Text(document.fileName)
+                .font(.caption)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+        .onTapGesture {
+            viewModel.openFile(document: document)
+        }
+        .onLongPressGesture {
+            viewModel.toggleFavorite(document: document)
+            favoriteAlertMessage = document.isFavorite ? "\(document.fileName) removed from Favorites" : "\(document.fileName) added to Favorites"
+            isShowingFavoriteAlert = true
+        }
+        .alert(isPresented: $isShowingFavoriteAlert) {
+            Alert(title: Text("Favorites"), message: Text(favoriteAlertMessage), dismissButton: .default(Text("OK")))
+        }
+    }
+    func presentFavoritesActionSheet() {
+        // Implement action sheet or context menu for favorites
+        print("Long pressed on \(document.fileName)")
+        // Example using an action sheet (requires a @State var to control presentation)
+        // You'll need to add a @State var in AllView to handle this.
+        // isPresentingFavoritesOptions = true
     }
 }
 

--- a/StudyBuddy/ViewModels/FileViewerViewModel/FileViewerViewModel.swift
+++ b/StudyBuddy/ViewModels/FileViewerViewModel/FileViewerViewModel.swift
@@ -5,7 +5,131 @@
 //  Created by Tony Nguyen on 2/27/25.
 //
 import Foundation
+import FirebaseStorage
+import QuickLook
 
 class FileViewerViewModel: ObservableObject {
-    @Published var fileLibrary: [String] = ["Document1.pdf", "Image1.png", "Report.docx"]
+    @Published var documents: [Document] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var selectedFileURL: URL?
+    @Published var isPresentingFilePreview: Bool = false
+    @Published var localFileURL: URL?
+
+    private let storage = Storage.storage()
+    private let storagePath = "documents/"
+
+    init() {
+        fetchDocumentsFromStorage()
+    }
+
+    func fetchDocumentsFromStorage() {
+        isLoading = true
+        errorMessage = nil
+        documents = []
+
+        let storageReference = storage.reference().child(storagePath)
+
+        storageReference.listAll { (result, error) in
+            DispatchQueue.main.async {
+                self.isLoading = false
+                if let error = error {
+                    self.errorMessage = "Error fetching files from Storage: \(error.localizedDescription)"
+                    print("Error fetching files from Storage: \(error)")
+                    return
+                }
+
+                guard let items = result?.items else {
+                    print("No files found in Storage at path: \(self.storagePath)")
+                    return
+                }
+
+                self.documents = items.map { item in
+                    let fileName = item.name
+                    return Document(fileName: fileName, content: "", fileURL: nil, type: .file, isFavorite: false) // Initialize isFavorite to false
+                }
+
+                for index in 0..<self.documents.count {
+                    let document = self.documents[index]
+                    let fileReference = storageReference.child(document.fileName)
+                    fileReference.downloadURL { (url, error) in
+                        if let error = error as NSError? {
+                            print("Error getting download URL for \(document.fileName): \(error.localizedDescription) (Code: \(error.code), Domain: \(error.domain))")
+                        } else if let downloadURL = url {
+                            DispatchQueue.main.async {
+                                self.documents[index].fileURL = downloadURL.absoluteString
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Function to handle opening a file
+        func openFile(document: Document) {
+            guard let remoteFileURL = document.fileURL, let url = URL(string: remoteFileURL) else {
+                print("Invalid file URL for \(document.fileName)")
+                return
+            }
+            print("Opening file: \(document.fileName) at URL: \(url)")
+            selectedFileURL = url
+            downloadAndPresentFile(from: url)
+        }
+
+        private func downloadAndPresentFile(from remoteURL: URL) {
+            isLoading = true
+            errorMessage = nil
+            let fileName = remoteURL.lastPathComponent
+            let documentsDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let localFile = documentsDirectoryURL.appendingPathComponent(fileName)
+
+            // Check if the file is already downloaded
+            if FileManager.default.fileExists(atPath: localFile.path) {
+                print("File already downloaded at: \(localFile)")
+                self.localFileURL = localFile
+                self.isPresentingFilePreview = true
+                self.isLoading = false
+                return
+            }
+
+            URLSession.shared.downloadTask(with: remoteURL) { (location, response, error) in
+                DispatchQueue.main.async {
+                    self.isLoading = false
+                    if let error = error {
+                        self.errorMessage = "Error downloading file: \(error.localizedDescription)"
+                        print("Error downloading file: \(error)")
+                        return
+                    }
+
+                    guard let tempLocation = location else {
+                        self.errorMessage = "Error: No temporary file location found."
+                        print("Error: No temporary file location found.")
+                        return
+                    }
+
+                    do {
+                        try FileManager.default.moveItem(at: tempLocation, to: localFile)
+                        print("File downloaded successfully to: \(localFile)")
+                        self.localFileURL = localFile
+                        self.isPresentingFilePreview = true
+                    } catch {
+                        self.errorMessage = "Error moving downloaded file: \(error.localizedDescription)"
+                        print("Error moving downloaded file: \(error)")
+                    }
+                }
+            }.resume()
+        }
+    func toggleFavorite(document: Document) {
+        if let index = documents.firstIndex(where: { $0.id == document.id }) {
+            documents[index].isFavorite.toggle()
+            print("\(documents[index].fileName) is now favorite: \(documents[index].isFavorite)")
+            // In a real app, you would likely want to persist this state (e.g., in Firestore or locally).
+        }
+    }
+
+    // Computed property to filter favorite documents
+    var favoriteDocuments: [Document] {
+        return documents.filter { $0.isFavorite }
+    }
 }


### PR DESCRIPTION
- viewmodel query Firestore and Cloud Storage from https://github.com/gtiosclub/StudyBuddy/issues/66 and display all of the users documents on screen. (files are pulled from filestore storage #70)
- Files are visible on the screen in rows of 3 #71 
- Files can be interacted with - pressing a file opens it #72
- Files can be long-pressed to pull up a favorites option. A message pops up notifying the user that the file is added/removed from favorite. Changes can be seen in the favorite folder tab correspondingly.
- For adding files to folders function, didn't implement the details since there are no folders except for the favorite folder, but could work more on this in the future.