### PR TITLE
Add generate flashcards functionality with OpenAI

### DIFF
--- a/StudyBuddy/Models/AI/OpenAIManager.swift
+++ b/StudyBuddy/Models/AI/OpenAIManager.swift
@@ -27,6 +27,9 @@ final class OpenAIManager: IntelligenceManager {
         }
         
         let jsonData = try JSONEncoder().encode(requestData)
+//        if let jsonString = String(data: jsonData, encoding: .utf8) {
+//            print(jsonString)
+//        }
 
         var request = URLRequest(url: baseURL)
         request.httpMethod = "POST"
@@ -50,8 +53,54 @@ final class OpenAIManager: IntelligenceManager {
 
         return OpenAIIntelligenceResponse(output: output)
     }
+
+    // swiftlint:disable:next function_body_length
+    func makeFlashcards(content: [String]) async throws -> [(String, String)] {
+        var messages: [OpenAIRequest.Message] = [
+            .init(role: "system", content: """
+            Your task is condensing the information from all the source documents and identifying key concepts that a student would need to learn for an exam. 
+            The end goal is creating flashcards for each of the key concepts.
+            Each flashcard should have a question and an answer.
+            """)
+        ]
+
+        for document in content {
+            messages.append(.init(role: "user", content: document))
+        }
+
+        let flashcardRequest = OpenAIRequest(
+            input: "",
+            model: .openai_4o_mini,
+            messages: messages,
+            maxCompletionTokens: 1000,
+            temperature: 0.7,
+            responseFormat: OpenAIRequest.flashcardResponseFormatStruct
+        )
+
+        let response = try await self.makeRequest(flashcardRequest)
+
+        let flashcardResponse =
+        try JSONDecoder()
+            .decode(
+                OpenAIFlashcardResponse.self,
+                from: response.output.data(using: .utf8)!
+            )
+
+        let flashcards = flashcardResponse.flashcards.map { ($0.question, $0.answer) }
+
+        return flashcards
+    }
 }
 
 struct OpenAIIntelligenceResponse: IntelligenceResponse {
     var output: String
+}
+
+struct OpenAIFlashcardResponse: Decodable {
+    let flashcards: [OpenAIFlashcard]
+}
+
+struct OpenAIFlashcard: Decodable {
+    let question: String
+    let answer: String
 }

--- a/StudyBuddy/Models/AI/OpenAIRequest.swift
+++ b/StudyBuddy/Models/AI/OpenAIRequest.swift
@@ -13,14 +13,99 @@ struct OpenAIRequest: Encodable, IntelligenceRequest {
     let messages: [Message]
     let maxCompletionTokens: Int?
     let temperature: Double?
+    var responseFormat: ResponseFormat?
 
     enum CodingKeys: String, CodingKey {
         case model, messages, temperature
         case maxCompletionTokens = "max_completion_tokens"
+        case responseFormat = "response_format"
     }
 
     struct Message: Codable {
         let role: String
         let content: String
+    }
+
+    static let flashcardResponseFormatStruct: ResponseFormat = .init(
+        type: "json_schema",
+        jsonSchema: .init(
+            name: "flashcards",
+            strict: true,
+            schema: .init(
+                type: "object",
+                properties: .init(
+                    flashcards: .init(
+                        type: "array",
+                        items: .init(
+                            type: "object",
+                            properties: .init(
+                                question: .init(type: "string"),
+                                answer: .init(type: "string")),
+                            required: [
+                                "question",
+                                "answer"
+                            ],
+                            additionalProperties: false
+                        )
+                    )
+                ),
+                required: [
+                    "flashcards"
+                ],
+                additionalProperties: false
+            )
+        )
+    )
+
+    struct ResponseFormat: Encodable {
+        let type: String
+        let jsonSchema: JsonSchema
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case jsonSchema = "json_schema"
+        }
+
+        struct JsonSchema: Encodable {
+            let name: String
+            let strict: Bool
+            let schema: Schema
+
+            struct Schema: Encodable {
+                let type: String
+                let properties: Properties
+                let required: [String]
+                let additionalProperties: Bool
+
+                struct Properties: Encodable {
+                    let flashcards: Flashcards
+
+                    struct Flashcards: Encodable {
+                        let type: String
+                        let items: Item
+
+                        struct Item: Encodable {
+                            let type: String
+                            let properties: Properties
+                            let required: [String]
+                            let additionalProperties: Bool
+
+                            struct Properties: Encodable {
+                                let question: Question
+                                let answer: Answer
+
+                                struct Question: Encodable {
+                                    let type: String
+                                }
+
+                                struct Answer: Encodable {
+                                    let type: String
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Summary:
- added the `makeFlashcards` method to OpenAIManager in order to take in documents and use them to generate flashcards with the OpenAI API.

This pull request introduces a new feature to generate flashcards from given content using the OpenAI API. The most important changes include the addition of a new method for creating flashcards, the introduction of new data structures to handle the flashcard responses, and the extension of the `OpenAIRequest` struct to support the new response format.

New feature implementation:

* Added `makeFlashcards` method to the `OpenAIManager` class to generate flashcards from provided content. This method constructs a request, sends it to the OpenAI API, and parses the response into a list of flashcards.

Data structure additions:

* Introduced `OpenAIFlashcardResponse` and `OpenAIFlashcard` structs to model the flashcard response from the OpenAI API.

Enhancements to request handling:

* Extended the `OpenAIRequest` struct to include a `responseFormat` property and added a static `flashcardResponseFormatStruct` for defining the response format expected for flashcard generation.

Code cleanup:

* Commented out unused print statements in the `OpenAIManager` class to improve code readability.