### PR TITLE
fix document upload and show flashcards immediately after being created

### DIFF
--- a/StudyBuddy/Models/UploadModel/DocumentsModel.swift
+++ b/StudyBuddy/Models/UploadModel/DocumentsModel.swift
@@ -5,6 +5,8 @@
 //  Created by Krish Kapoor on 20/02/2025.
 //
 import Foundation
+import FirebaseFirestore
+
 enum DocumentType: String, Codable {
     case file
     case folder
@@ -12,7 +14,7 @@ enum DocumentType: String, Codable {
 /// Represents a document in the StudyBuddy app.
 /// Stores the document name, raw content, parsed content (if available), and creation date.
 struct Document: Identifiable, Codable {
-    let id: UUID  // Unique identifier for each document
+    @DocumentID var id: String?  // Unique identifier for each document
     let fileName: String  // Name of the document file
     let content: String  // Raw content of the document
     let dateCreated: Date  // Timestamp when the document was created
@@ -33,7 +35,7 @@ struct Document: Identifiable, Codable {
     init(fileName: String, content: String, parsedContent: String? = nil,
          fileData: Data? = nil, fileURL: String? = nil,
          type: DocumentType = .file, isFavorite: Bool = false, userID: String, isPrivate: Bool) {
-        self.id = UUID()  // Generate a unique ID
+        self.id = UUID().uuidString  // Generate a unique ID
         self.fileName = fileName
         self.content = content
         self.dateCreated = Date()  // Set creation timestamp
@@ -51,6 +53,10 @@ struct Document: Identifiable, Codable {
     /// - Parameter parsed: The extracted text from the document.
     mutating func updateParsedContent(_ parsed: String) {
         self.parsedContent = parsed
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case id, fileName, content, dateCreated, parsedContent, fileURL, type, isFavorite, firestoreDocumentId, userID, isPrivate
     }
 }
 // Example usage:

--- a/StudyBuddy/Screens/FileViewer/FileViewer.swift
+++ b/StudyBuddy/Screens/FileViewer/FileViewer.swift
@@ -109,6 +109,7 @@ struct FileViewer: View {
             }
             .onChange(of: uploadViewModel.isUploadPresented) { isPresented in
                 if isPresented {
+                    uploadViewModel.selectedDocumentNames = []
                     isUploadViewPresented = true
                 }
             }

--- a/StudyBuddy/Screens/Flashcards/SetView.swift
+++ b/StudyBuddy/Screens/Flashcards/SetView.swift
@@ -254,7 +254,7 @@ struct SetView: View {
                             let flashcards = try await studySetVM.generateFlashcards()
                             print(flashcards)
 
-                            studySetVM.currentlyChosenStudySet.flashcards.append(contentsOf: flashcards)
+                            self.flashcards.append(contentsOf: flashcards)
                         } catch {
                             print("Error generating flashcards: \(error)")
                         }

--- a/StudyBuddy/ViewModels/FileViewerViewModel/FileViewerViewModel.swift
+++ b/StudyBuddy/ViewModels/FileViewerViewModel/FileViewerViewModel.swift
@@ -49,14 +49,27 @@ class FileViewerViewModel: ObservableObject {
                             return nil
                         }
                     }
-                    for index in 0..<self.documents.count {
-                        let document = self.documents[index]
+//                    for index in 0..<self.documents.count {
+//                        let document = self.documents[index]
+//                        let fileReference = storageReference.child(document.fileName)
+//                        fileReference.downloadURL { (url, error) in
+//                            if let error = error as NSError? {
+//                                print("Error getting download URL for \(document.fileName): \(error.localizedDescription) (Code: \(error.code), Domain: \(error.domain))")
+//                            } else if let downloadURL = url {
+//                                DispatchQueue.main.async {
+//                                    self.documents[index].fileURL = downloadURL.absoluteString
+//                                }
+//                            }
+//                        }
+//                    }
+                    for document in self.documents {
                         let fileReference = storageReference.child(document.fileName)
                         fileReference.downloadURL { (url, error) in
                             if let error = error as NSError? {
                                 print("Error getting download URL for \(document.fileName): \(error.localizedDescription) (Code: \(error.code), Domain: \(error.domain))")
                             } else if let downloadURL = url {
                                 DispatchQueue.main.async {
+                                    guard let index = self.documents.firstIndex(where: { $0.id == document.id }) else { return }
                                     self.documents[index].fileURL = downloadURL.absoluteString
                                 }
                             }

--- a/StudyBuddy/ViewModels/StudySetViewModel.swift
+++ b/StudyBuddy/ViewModels/StudySetViewModel.swift
@@ -50,7 +50,7 @@ class StudySetViewModel: ObservableObject, Identifiable {
             print("Document ID not found in updateStudySetDocument.")
             return
         }
-        let documentIDs: [String] = documents.map { $0.id.uuidString }
+        let documentIDs: [String] = documents.compactMap { $0.id }
         let docRef = db.collection("StudySets").document(studySetID)
         print(documentIDs)
         docRef.updateData([

--- a/StudyBuddy/ViewModels/UploadViewModel/UploadViewModel.swift
+++ b/StudyBuddy/ViewModels/UploadViewModel/UploadViewModel.swift
@@ -47,9 +47,10 @@ class UploadViewModel: ObservableObject {
         let collectionRef = Firestore.firestore().collection("Documents")
         do {
             var newDocument = document
-            let docRef = try collectionRef.addDocument(from: newDocument)
-            newDocument.firestoreDocumentId = docRef.documentID
-            print("Document stored in FileViewModel\(docRef.documentID)")
+            
+            guard let id = newDocument.id else { return }
+            try collectionRef.document(id).setData(from: newDocument)
+            print("Document stored in FileViewModel\(newDocument.id)")
         } catch {
             print("Error in UploadViewModel while doing uploadDocument \(error)")
         }


### PR DESCRIPTION
This pull request includes several changes to the `StudyBuddy` app, primarily focusing on the `DocumentsModel` and various view models. The most important changes include updating the `Document` structure to use Firestore, modifying view models to handle document IDs correctly, and small improvements in the `FileViewer` and `SetView` views.

### Changes to `Document` structure:

* [`StudyBuddy/Models/UploadModel/DocumentsModel.swift`](diffhunk://#diff-09a41723f8cb987890df1a126b51be59fbcaae989a4784ab54eb1110a336bc67R8-R17): Updated the `Document` structure to use Firestore by importing `FirebaseFirestore`, changing `id` to use `@DocumentID`, and adding a `CodingKeys` enum to map properties to Firestore fields. [[1]](diffhunk://#diff-09a41723f8cb987890df1a126b51be59fbcaae989a4784ab54eb1110a336bc67R8-R17) [[2]](diffhunk://#diff-09a41723f8cb987890df1a126b51be59fbcaae989a4784ab54eb1110a336bc67L36-R38) [[3]](diffhunk://#diff-09a41723f8cb987890df1a126b51be59fbcaae989a4784ab54eb1110a336bc67R57-R60)

### View model updates:

* [`StudyBuddy/ViewModels/FileViewerViewModel/FileViewerViewModel.swift`](diffhunk://#diff-b35baf7733d898480c72df8207139cc4a60e9c5a07e4573d96bab7373655f028L52-R72): Modified the loop for downloading URLs to correctly update the `fileURL` of documents by finding the index of each document.
* [`StudyBuddy/ViewModels/StudySetViewModel.swift`](diffhunk://#diff-bfa0a1e1c5bf117fcca841d1c2d401cd197b87327f5b3209e9da5f22072b5573L53-R53): Changed the `documentIDs` array to use `compactMap` to handle optional `id` values correctly.
* [`StudyBuddy/ViewModels/UploadViewModel/UploadViewModel.swift`](diffhunk://#diff-db7abe639644cec9ee656ad5dd058e731da371e500fe02628647fcef1d77e28aL50-R53): Updated the `uploadDocument` method to use the document's `id` for setting data in Firestore instead of generating a new document ID.

### View improvements:

* [`StudyBuddy/Screens/FileViewer/FileViewer.swift`](diffhunk://#diff-2bd105dd69216c73aa095322c569ee76724397f4781b0644c127e54697ee6adeR112): Reset `selectedDocumentNames` when `isUploadPresented` changes to `true`.
* [`StudyBuddy/Screens/Flashcards/SetView.swift`](diffhunk://#diff-4e0dbde1f090e48a617b20d1703d58d7d62222be4b05e138c294b2dcecad8a51L257-R257): Fixed appending flashcards to the correct list in the `SetView`.